### PR TITLE
Update npm version and resolve dependencies

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -23,6 +23,9 @@
         "prisma": "^6.9.0",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "npm": ">=11.4.2"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -458,9 +461,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -12,6 +12,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "npm": ">=11.4.2"
+  },
   "dependencies": {
     "@prisma/client": "^6.9.0",
     "cors": "^2.8.5",

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -27,7 +27,6 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
-        "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
         "@types/react": "^18.2.37",
@@ -44,6 +43,9 @@
         "ts-jest": "^29.4.0",
         "typescript": "^5.4.2",
         "vite": "^5.2.0"
+      },
+      "engines": {
+        "npm": ">=11.4.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3102,37 +3104,6 @@
         }
       }
     },
-    "node_modules/@testing-library/react-hooks": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
-      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-test-renderer": "^16.9.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-test-renderer": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
@@ -3353,14 +3324,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -9366,23 +9337,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      }
-    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
@@ -11290,7 +11244,7 @@
       "version": "8.18.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
       "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -11,6 +11,9 @@
     "lint": "eslint src --ext .ts,.tsx --fix",
     "lint:check": "eslint src --ext .ts,.tsx"
   },
+  "engines": {
+    "npm": ">=11.4.2"
+  },
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.8.2",
@@ -31,7 +34,6 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/react": "^18.2.37",

--- a/apps/frontend/src/components/PromptophonePhase.tsx
+++ b/apps/frontend/src/components/PromptophonePhase.tsx
@@ -17,7 +17,7 @@ import {
   Divider,
 } from '@chakra-ui/react';
 import { useGame } from '../context/GameContext';
-import { gameWords } from '../../shared/data/words';
+import { gameWords } from '../data/words';
 import { API_URL } from '../utils/env';
 
 const ROUND_DURATION = 60; // 60 seconds for prompt phase
@@ -246,7 +246,7 @@ export const PromptophonePhase: React.FC = () => {
   };
 
   // Get exclusion words for the chain's original word
-  const exclusionWords = (gameWords.find(w => w.word.toLowerCase() === assignedChain.originalWord.toLowerCase())?.exclusionWords) || [];
+  const exclusionWords = (gameWords.find(w => w.word.toLowerCase() === assignedChain.originalWord.toLowerCase())?.excluded) || [];
 
   return (
     <VStack spacing={8} align="stretch" maxW="1200px" mx="auto" p={4}>

--- a/apps/frontend/src/context/__tests__/GameContext.test.tsx
+++ b/apps/frontend/src/context/__tests__/GameContext.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { render, screen, fireEvent, waitFor, renderHook } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../AuthContext';
 import { BrowserRouter } from 'react-router-dom';
 import { GameProvider, useGame } from '../GameContext';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Promptionary",
+  "name": "workspace",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
@@ -12,6 +12,9 @@
         "@react-oauth/google": "^0.12.2",
         "framer-motion": "^12.16.0",
         "react-icons": "^5.5.0"
+      },
+      "engines": {
+        "npm": ">=11.4.2"
       }
     },
     "node_modules/@ark-ui/react": {

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
     "@react-oauth/google": "^0.12.2",
     "framer-motion": "^12.16.0",
     "react-icons": "^5.5.0"
+  },
+  "engines": {
+    "npm": ">=11.4.2"
   }
 }


### PR DESCRIPTION
The global npm version was updated to 11.4.2. To enforce this, the `"engines": { "npm": ">=11.4.2" }` field was added to the root `/workspace/package.json` and the application-specific `/workspace/apps/backend/package.json` and `/workspace/apps/frontend/package.json` files.

Dependency issues were resolved:
*   The deprecated `@testing-library/react-hooks` package was removed from `/workspace/apps/frontend/package.json`. Its usage in `/workspace/apps/frontend/src/context/__tests__/GameContext.test.tsx` was updated to import `renderHook` directly from `@testing-library/react`, which now includes the functionality.
*   In `/workspace/apps/frontend/src/components/PromptophonePhase.tsx`, an import path for `gameWords` was corrected to use the local data file (`../data/words`) instead of a shared path.
*   A property name in `/workspace/apps/frontend/src/components/PromptophonePhase.tsx` was updated from `exclusionWords` to `excluded` to match the `WordData` interface.

Following these changes, all frontend tests passed, and both frontend and backend builds completed successfully, ensuring full compatibility with npm 11.4.2.